### PR TITLE
improve-from-agent-debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,5 @@ uv.lock
 
 .deployment/
 .playwright-cli/
+/
+but/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,21 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### v0.10.29 (dev)
+
+- **Dialog HITL** — New HITL type for interactive content review via chat interface. When a `CaseNodeUpdate` payload contains `supervaizer_dialog`, the workbench renders a conversation UI instead of a fixed form. Supports iterative refinement through LLM-powered feedback loops. Fields: `content` (JSON string), `content_type` (email/text/code), `objective`, `instructions`, `messages` (conversation history), `confirm_label`.
+  - Template: `dialog_renderer.html` with `render_hitl_dialog` and `render_dialog_confirmed` macros
+  - JS: `submitDialogMessage(caseId, message)` and `confirmDialog(caseId)` in `workbench-form.js`
+  - Route: `workbench_routes.py` detects `supervaizer_dialog` in AWAITING case payloads
+
+- **Local mode URL fixes** — `supervaizer start --local --port N` now correctly shows localhost URLs everywhere: CLI output, admin interface logs, storage, and uvicorn. Fixed by resolving `Server.__init__` defaults from env vars at call time (not class definition time) and ensuring CLI-provided values take precedence over `.env` file values.
+
+- **Local mode event skipping** — `account_service.send_event()` returns a no-op `ApiSuccess` when `SUPERVAIZER_LOCAL_MODE=true`, preventing HTTP errors against the SaaS API during local development.
+
+- **Agent parameter env pre-fill** — In local mode, the workbench auto-loads `.env` values into agent parameter fields with green `.env` badge indicators. Secret fields show a masked placeholder; non-secret fields display the value. Backend falls back to env values for empty fields on job submission.
+
+- **HTMX polling guard** — Monitor template suppresses `hx-trigger` polling when a HITL dialog or form is active, preventing DOM overwrites while users interact with forms.
+
 ### v0.10.27
 
 - **Agent Workbench** — Full-featured testing interface for agents directly from the admin panel. Four-zone layout with agent parameters, job control, execution monitor, and live console log. Supports starting/stopping jobs, real-time case and step tracking via HTMX polling, and Human-in-the-Loop (HITL) form rendering and submission. Job history panel lists all past executions with status badges.

--- a/src/supervaizer/account_service.py
+++ b/src/supervaizer/account_service.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Union
 
 import httpx
 
-from supervaizer.common import ApiError, ApiResult, ApiSuccess, log
+from supervaizer.common import ApiError, ApiResult, ApiSuccess, is_local_mode, log
 
 logger = logging.getLogger("httpx")
 # Enable httpx debug logging (optional - uncomment for transport-level debugging)
@@ -56,6 +56,11 @@ def send_event(
 
         Tested in tests/test_account_service.py
     """
+
+    # In local mode, skip sending events to the SaaS API entirely.
+    if is_local_mode():
+        log.debug(f"[Send event] Local mode — skipping {event.type.name}")
+        return ApiSuccess(message=f"Event {event.type.name} skipped (local mode)", detail=None)
 
     headers = account.api_headers
     payload = event.payload

--- a/src/supervaizer/account_service.py
+++ b/src/supervaizer/account_service.py
@@ -60,7 +60,9 @@ def send_event(
     # In local mode, skip sending events to the SaaS API entirely.
     if is_local_mode():
         log.debug(f"[Send event] Local mode — skipping {event.type.name}")
-        return ApiSuccess(message=f"Event {event.type.name} skipped (local mode)", detail=None)
+        return ApiSuccess(
+            message=f"Event {event.type.name} skipped (local mode)", detail=None
+        )
 
     headers = account.api_headers
     payload = event.payload

--- a/src/supervaizer/admin/routes.py
+++ b/src/supervaizer/admin/routes.py
@@ -1223,12 +1223,17 @@ def create_admin_routes() -> APIRouter:
             return {"status": "error", "message": str(e)}
 
     # Include workbench sub-router
-    from supervaizer.admin.workbench_routes import create_workbench_routes
+    from supervaizer.admin.workbench_routes import (
+        create_workbench_routes,
+        create_workbench_ws_routes,
+    )
 
     router.include_router(
         create_workbench_routes(),
         dependencies=[Depends(verify_admin_access)],
     )
+    # WebSocket routes are mounted separately — WS can't use APIKeyHeader auth
+    router.include_router(create_workbench_ws_routes())
 
     return router
 

--- a/src/supervaizer/admin/static/js/workbench-form.js
+++ b/src/supervaizer/admin/static/js/workbench-form.js
@@ -18,7 +18,7 @@ class WorkbenchForm {
         this._getFields = config.getFields || null;
         if (config.onJobStarted) this.onJobStarted = config.onJobStarted;
         if (config.onError) this.onError = config.onError;
-        this._pollInterval = null;
+        this._ws = null;
     }
 
     getApiKey() {
@@ -157,6 +157,35 @@ class WorkbenchForm {
         }
     }
 
+    /** Shared POST to /cases/{caseId}/answer endpoint. */
+    async _postAnswer(caseId, answerPayload) {
+        if (!this.activeJobId) return null;
+        try {
+            const response = await fetch(
+                `${this.basePath}/jobs/${this.activeJobId}/cases/${caseId}/answer`,
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-API-Key': this.getApiKey(),
+                    },
+                    body: JSON.stringify({ answer: answerPayload }),
+                },
+            );
+            const result = await response.json();
+            if (!response.ok) {
+                this.onError(result.detail || result.message || 'Failed to submit answer');
+                return null;
+            }
+            this.onError('');
+            this.refreshMonitor(true);
+            return result;
+        } catch (e) {
+            this.onError(`Network error: ${e.message}`);
+            return null;
+        }
+    }
+
     async submitHitlAnswer(caseId, formElement) {
         const answer = {};
         new FormData(formElement).forEach((value, key) => {
@@ -171,29 +200,19 @@ class WorkbenchForm {
             }
         });
 
-        try {
-            const response = await fetch(
-                `${this.basePath}/jobs/${this.activeJobId}/cases/${caseId}/answer`,
-                {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-API-Key': this.getApiKey(),
-                    },
-                    body: JSON.stringify({ answer }),
-                },
-            );
-            const result = await response.json();
-            if (!response.ok) {
-                this.onError(result.detail || result.message || 'Failed to submit answer');
-            } else {
-                // Remove the form so polling resumes, then refresh immediately
-                formElement.remove();
-                this.refreshMonitor();
-            }
-        } catch (e) {
-            this.onError(`Network error: ${e.message}`);
+        const result = await this._postAnswer(caseId, answer);
+        if (result) {
+            formElement.remove();
         }
+    }
+
+    async submitDialogMessage(caseId, message) {
+        if (!message) return;
+        await this._postAnswer(caseId, { action: 'message', text: message });
+    }
+
+    async confirmDialog(caseId) {
+        await this._postAnswer(caseId, { action: 'confirm' });
     }
 
     /** Show/hide Stop and Status buttons based on active job. */
@@ -209,14 +228,29 @@ class WorkbenchForm {
         }
     }
 
-    /** Fetch and render the monitor partial for the active job. */
-    refreshMonitor() {
+    /** True when a HITL dialog or form is visible in the monitor. */
+    _hasActiveHitl() {
+        const container = document.getElementById(this.monitorContainerId);
+        if (!container) return false;
+        return !!(
+            container.querySelector('form[id^="hitl-form-"]') ||
+            container.querySelector('[id^="hitl-dialog-"]')
+        );
+    }
+
+    /** Fetch and render the monitor partial for the active job.
+     *  @param {boolean} force - bypass HITL guard (used after dialog submit/confirm)
+     */
+    refreshMonitor(force) {
         if (!this.activeJobId) return;
         const container = document.getElementById(this.monitorContainerId);
         if (!container) return;
+        // Don't overwrite while user interacts with HITL (unless forced)
+        if (!force && this._hasActiveHitl()) return;
         const url = `${this.basePath}/jobs/${this.activeJobId}`;
         const apiKey = this.getApiKey();
         const headers = apiKey ? { 'X-API-Key': apiKey } : {};
+        const self = this;
         fetch(url, { headers })
             .then(r => r.text())
             .then(html => {
@@ -224,46 +258,109 @@ class WorkbenchForm {
                 if (typeof Alpine !== 'undefined') {
                     Alpine.initTree(container);
                 }
+                // Disconnect WebSocket when job reaches terminal state
+                const partial = container.querySelector('#workbench-monitor-partial');
+                if (partial && partial.dataset.jobTerminal === 'true') {
+                    self.disconnectWebSocket();
+                    self._updateButtons(true);
+                }
             })
             .catch(() => {});
     }
 
-    /** Load monitor partial and start polling. Stops when job reaches terminal state. */
+    /** Check if the monitor shows a terminal job state. */
+    _isJobTerminal() {
+        var container = document.getElementById(this.monitorContainerId);
+        if (!container) return false;
+        var partial = container.querySelector('#workbench-monitor-partial');
+        return partial && partial.dataset.jobTerminal === 'true';
+    }
+
+    /** Connect a WebSocket that pushes typed signals when state changes. */
+    connectWebSocket(jobId) {
+        // Don't connect for terminal jobs
+        if (this._isJobTerminal()) return;
+        this.disconnectWebSocket();
+        const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsUrl = `${protocol}//${location.host}${this.basePath}/jobs/${jobId}/ws`;
+        this._ws = new WebSocket(wsUrl);
+        const self = this;
+        this._ws.onmessage = (event) => {
+            const msg = event.data;
+            if (msg === 'terminal') {
+                self.refreshMonitor(true);
+                self._refreshConsole();
+                self._refreshJobsList();
+                self.disconnectWebSocket();
+                self._updateButtons(true);
+            } else if (msg === 'monitor' || msg === 'refresh') {
+                self.refreshMonitor();
+            } else if (msg === 'console') {
+                self._refreshConsole();
+            } else if (msg === 'jobs') {
+                self._refreshJobsList();
+            } else if (msg === 'ping') {
+                self._ws.send('pong');
+            }
+        };
+        this._ws.onclose = () => {
+            // Only reconnect if job is still active and we didn't intentionally disconnect
+            if (self.activeJobId && self._ws && !self._isJobTerminal()) {
+                self._ws = null;
+                setTimeout(() => {
+                    if (self.activeJobId && !self._isJobTerminal()) {
+                        self.connectWebSocket(jobId);
+                    }
+                }, 3000);
+            }
+        };
+        this._ws.onerror = () => {};
+    }
+
+    /** Fetch and swap console log entries. */
+    _refreshConsole() {
+        var el = document.getElementById('console-log-container');
+        if (!el) return;
+        var url = el.dataset.url;
+        if (!url) return;
+        fetch(url).then(r => r.text()).then(html => {
+            el.innerHTML = html;
+            el.scrollTop = el.scrollHeight;
+            if (typeof applyConsoleFilter === 'function') applyConsoleFilter();
+        }).catch(() => {});
+    }
+
+    /** Fetch and swap job history list. */
+    _refreshJobsList() {
+        var el = document.getElementById('jobs-list-container');
+        if (!el) return;
+        var url = el.dataset.url;
+        if (!url) return;
+        fetch(url).then(r => r.text()).then(html => {
+            el.innerHTML = html;
+        }).catch(() => {});
+    }
+
+    /** Close the WebSocket connection. */
+    disconnectWebSocket() {
+        if (this._ws) {
+            const ws = this._ws;
+            this._ws = null;
+            ws.close();
+        }
+    }
+
+    /** Load monitor partial and connect WebSocket for live updates. */
     onJobStarted(result) {
         const container = document.getElementById(this.monitorContainerId);
         if (!container) return;
-        const url = `${this.basePath}/jobs/${result.id}`;
-        const apiKey = this.getApiKey();
-        const self = this;
         this._updateButtons(false);
-        const loadMonitor = () => {
-            // Don't overwrite the monitor while user is filling a HITL form
-            if (container.querySelector('form[id^="hitl-form-"]')) return;
-
-            const headers = apiKey ? { 'X-API-Key': apiKey } : {};
-            fetch(url, { headers })
-                .then(r => r.text())
-                .then(html => {
-                    container.innerHTML = html;
-                    // Re-initialize Alpine on swapped content
-                    if (typeof Alpine !== 'undefined') {
-                        Alpine.initTree(container);
-                    }
-                    // Stop polling once job is terminal
-                    const partial = container.querySelector('#workbench-monitor-partial');
-                    if (partial && partial.dataset.jobTerminal === 'true') {
-                        if (self._pollInterval) {
-                            clearInterval(self._pollInterval);
-                            self._pollInterval = null;
-                        }
-                        self._updateButtons(true);
-                    }
-                })
-                .catch(() => {});
-        };
-        loadMonitor();
-        if (this._pollInterval) clearInterval(this._pollInterval);
-        this._pollInterval = setInterval(loadMonitor, 2000);
+        // Initial load
+        this.refreshMonitor();
+        this._refreshConsole();
+        this._refreshJobsList();
+        // Connect WebSocket — pushes monitor, console, and jobs updates
+        this.connectWebSocket(result.id);
     }
 
     /** Show error in errors container. Override in template if needed. */

--- a/src/supervaizer/admin/static/js/workbench-form.js
+++ b/src/supervaizer/admin/static/js/workbench-form.js
@@ -122,6 +122,35 @@ class WorkbenchForm {
         }
     }
 
+    async pollJob() {
+        if (!this.activeJobId) return;
+        const btn = document.getElementById('btn-poll');
+        if (btn) {
+            btn.disabled = true;
+            btn.classList.add('opacity-50');
+        }
+        try {
+            const response = await fetch(`${this.basePath}/jobs/${this.activeJobId}/poll`, {
+                method: 'POST',
+                headers: { 'X-API-Key': this.getApiKey() },
+            });
+            const result = await response.json();
+            if (!response.ok) {
+                this.onError(result.detail || 'Poll failed');
+            } else {
+                this.onError('');
+                this.refreshMonitor(true);
+            }
+        } catch (e) {
+            this.onError(`Network error: ${e.message}`);
+        } finally {
+            if (btn) {
+                btn.disabled = false;
+                btn.classList.remove('opacity-50');
+            }
+        }
+    }
+
     async stopJob(jobId) {
         const targetJobId = jobId || this.activeJobId;
         if (!targetJobId) return;
@@ -232,15 +261,18 @@ class WorkbenchForm {
         await this._postAnswer(caseId, { action: 'confirm' });
     }
 
-    /** Show/hide Stop and Status buttons based on active job. */
+    /** Show/hide Stop, Poll, and Status buttons based on active job. */
     _updateButtons(terminal) {
         const stop = document.getElementById('btn-stop');
         const status = document.getElementById('btn-status');
+        const poll = document.getElementById('btn-poll');
         if (this.activeJobId && !terminal) {
             if (stop) stop.classList.remove('hidden');
             if (status) status.classList.remove('hidden');
+            if (poll) poll.classList.remove('hidden');
         } else {
             if (stop) stop.classList.add('hidden');
+            if (poll) poll.classList.add('hidden');
             if (status) status.classList.remove('hidden');
         }
     }

--- a/src/supervaizer/admin/static/js/workbench-form.js
+++ b/src/supervaizer/admin/static/js/workbench-form.js
@@ -157,9 +157,22 @@ class WorkbenchForm {
         }
     }
 
+    /** Disable/enable all HITL buttons in the monitor to prevent double-clicks. */
+    _setHitlButtonsDisabled(disabled) {
+        const container = document.getElementById(this.monitorContainerId);
+        if (!container) return;
+        container.querySelectorAll('button').forEach(btn => {
+            btn.disabled = disabled;
+            if (disabled) btn.classList.add('opacity-50', 'cursor-not-allowed');
+            else btn.classList.remove('opacity-50', 'cursor-not-allowed');
+        });
+    }
+
     /** Shared POST to /cases/{caseId}/answer endpoint. */
     async _postAnswer(caseId, answerPayload) {
-        if (!this.activeJobId) return null;
+        if (!this.activeJobId || this._submitting) return null;
+        this._submitting = true;
+        this._setHitlButtonsDisabled(true);
         try {
             const response = await fetch(
                 `${this.basePath}/jobs/${this.activeJobId}/cases/${caseId}/answer`,
@@ -175,6 +188,7 @@ class WorkbenchForm {
             const result = await response.json();
             if (!response.ok) {
                 this.onError(result.detail || result.message || 'Failed to submit answer');
+                this._setHitlButtonsDisabled(false);
                 return null;
             }
             this.onError('');
@@ -182,7 +196,10 @@ class WorkbenchForm {
             return result;
         } catch (e) {
             this.onError(`Network error: ${e.message}`);
+            this._setHitlButtonsDisabled(false);
             return null;
+        } finally {
+            this._submitting = false;
         }
     }
 

--- a/src/supervaizer/admin/templates/components/dialog_renderer.html
+++ b/src/supervaizer/admin/templates/components/dialog_renderer.html
@@ -24,16 +24,23 @@
                 catch(e) { console.warn('Dialog: failed to parse email JSON', e); }
             }
         },
-        submitMessage() {
+        async submitMessage() {
             const text = this.messageText.trim();
             if (!text || this.sending) return;
             this.sending = true;
-            window.workbenchForm && window.workbenchForm.submitDialogMessage('{{ case_id }}', text);
             this.messageText = '';
+            if (window.workbenchForm) {
+                await window.workbenchForm.submitDialogMessage('{{ case_id }}', text);
+            }
             this.sending = false;
         },
-        confirmDialog() {
-            window.workbenchForm && window.workbenchForm.confirmDialog('{{ case_id }}');
+        async confirmDialog() {
+            if (this.sending) return;
+            this.sending = true;
+            if (window.workbenchForm) {
+                await window.workbenchForm.confirmDialog('{{ case_id }}');
+            }
+            this.sending = false;
         }
     }"
 >

--- a/src/supervaizer/admin/templates/components/dialog_renderer.html
+++ b/src/supervaizer/admin/templates/components/dialog_renderer.html
@@ -1,0 +1,177 @@
+{# Dialog HITL renderer — chat-like interface for content review #}
+
+{% macro render_hitl_dialog(case_id, dialog) %}
+{% set content_raw = dialog.get("content", "") %}
+{% set content_type = dialog.get("content_type", "text") %}
+{% set objective = dialog.get("objective", "") %}
+{% set messages = dialog.get("messages", []) %}
+{% set confirm_label = dialog.get("confirm_label", "Approve") %}
+
+<div
+    id="hitl-dialog-{{ case_id }}"
+    class="mx-4 mb-4 mt-1 rounded-md border border-amber-200 bg-amber-50"
+    {% if content_type == "email" and content_raw %}
+    data-email-content="{{ content_raw | e }}"
+    {% endif %}
+    x-data="{
+        messageText: '',
+        sending: false,
+        emailData: null,
+        init() {
+            var raw = this.$el.dataset.emailContent;
+            if (raw) {
+                try { this.emailData = JSON.parse(raw); }
+                catch(e) { console.warn('Dialog: failed to parse email JSON', e); }
+            }
+        },
+        submitMessage() {
+            const text = this.messageText.trim();
+            if (!text || this.sending) return;
+            this.sending = true;
+            window.workbenchForm && window.workbenchForm.submitDialogMessage('{{ case_id }}', text);
+            this.messageText = '';
+            this.sending = false;
+        },
+        confirmDialog() {
+            window.workbenchForm && window.workbenchForm.confirmDialog('{{ case_id }}');
+        }
+    }"
+>
+    {# Header #}
+    <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+        <svg class="w-4 h-4 text-amber-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+        </svg>
+        <span class="text-sm font-semibold text-amber-800">Review &amp; Respond</span>
+    </div>
+
+    {# Objective #}
+    {% if objective %}
+    <div class="mx-4 mb-2 text-xs text-gray-500 italic">{{ objective }}</div>
+    {% endif %}
+
+    {# Content preview card #}
+    {% if content_raw %}
+    <div class="mx-4 mb-3 rounded border border-gray-200 bg-white overflow-hidden">
+        {% if content_type == "email" %}
+        {# Email: render subject + HTML body via Alpine #}
+        <template x-if="emailData">
+            <div>
+                <div class="px-3 pt-3 pb-1 border-b border-gray-100">
+                    <span class="text-xs font-medium text-gray-400 uppercase tracking-wider">Subject</span>
+                    <p class="text-sm font-medium text-gray-800 mt-0.5" x-text="emailData.subject"></p>
+                </div>
+                <div class="p-3 text-sm text-gray-700 max-h-64 overflow-y-auto prose prose-sm" x-html="emailData.html || emailData.text"></div>
+            </div>
+        </template>
+        <template x-if="!emailData">
+            <div class="p-3 text-sm text-gray-700 max-h-64 overflow-y-auto whitespace-pre-wrap">{{ content_raw }}</div>
+        </template>
+        {% elif content_type == "code" %}
+        <pre class="p-3 text-xs text-gray-700 max-h-64 overflow-y-auto bg-gray-50 font-mono whitespace-pre-wrap">{{ content_raw }}</pre>
+        {% else %}
+        <div class="p-3 text-sm text-gray-700 max-h-64 overflow-y-auto whitespace-pre-wrap">{{ content_raw }}</div>
+        {% endif %}
+    </div>
+    {% endif %}
+
+    {# Chat messages #}
+    <div
+        id="dialog-messages-{{ case_id }}"
+        class="mx-4 mb-3 rounded border border-gray-200 bg-white p-3 max-h-60 overflow-y-auto space-y-2"
+        x-init="$nextTick(() => { $el.scrollTop = $el.scrollHeight })"
+    >
+        {% if messages %}
+        {% for msg in messages %}
+        {% set role = msg.get("role", "assistant") %}
+        {% set text = msg.get("text", "") %}
+        {% if role == "user" %}
+        <div class="flex justify-end">
+            <div class="max-w-[75%] rounded-lg px-3 py-2 text-sm bg-blue-600 text-white">
+                {{ text }}
+            </div>
+        </div>
+        {% else %}
+        <div class="flex justify-start">
+            <div class="max-w-[75%] rounded-lg px-3 py-2 text-sm bg-gray-100 text-gray-800">
+                {{ text }}
+            </div>
+        </div>
+        {% endif %}
+        {% endfor %}
+        {% else %}
+        <div class="text-xs text-gray-400 italic text-center py-2">No messages yet.</div>
+        {% endif %}
+    </div>
+
+    {# Input + action buttons #}
+    <div class="mx-4 mb-3">
+        <div class="flex gap-2 mb-3">
+            <textarea
+                x-model="messageText"
+                @keydown.enter.prevent="if (!$event.shiftKey) { submitMessage() }"
+                placeholder="Suggest changes to the email... (Enter to send)"
+                rows="2"
+                class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-none"
+            ></textarea>
+            <button
+                type="button"
+                @click="submitMessage()"
+                :disabled="sending || !messageText.trim()"
+                class="self-end px-3 py-2 rounded-md text-xs font-medium text-blue-600 border border-blue-300 bg-blue-50 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+            >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
+                </svg>
+            </button>
+        </div>
+        <button
+            type="button"
+            @click="confirmDialog()"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md shadow-sm text-sm font-semibold text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 cursor-pointer transition-colors duration-150"
+        >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+            </svg>
+            {{ confirm_label }}
+        </button>
+    </div>
+</div>
+{% endmacro %}
+
+
+{# Confirmed content display — shown after dialog is approved #}
+{% macro render_dialog_confirmed(content_raw, content_type) %}
+<div class="mx-4 mb-3 rounded border border-green-200 bg-green-50 overflow-hidden">
+    <div class="px-3 py-2 bg-green-100 border-b border-green-200">
+        <span class="text-xs font-semibold text-green-700 uppercase tracking-wider flex items-center gap-1">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+            Approved Content
+        </span>
+    </div>
+    {% if content_type == "email" %}
+    <div data-email-content="{{ content_raw | e }}" x-data="{
+        email: null,
+        init() {
+            var raw = this.$el.dataset.emailContent;
+            if (raw) { try { this.email = JSON.parse(raw); } catch(e) {} }
+        }
+    }">
+        <template x-if="email">
+            <div>
+                <div class="px-3 pt-2 pb-1 border-b border-green-100">
+                    <span class="text-xs font-medium text-gray-400">Subject:</span>
+                    <span class="text-sm font-medium text-gray-800 ml-1" x-text="email.subject"></span>
+                </div>
+                <div class="p-3 text-sm text-gray-700 max-h-48 overflow-y-auto prose prose-sm" x-html="email.html || email.text"></div>
+            </div>
+        </template>
+        <template x-if="!email">
+            <div class="p-3 text-sm text-gray-700 max-h-48 overflow-y-auto whitespace-pre-wrap">{{ content_raw }}</div>
+        </template>
+    </div>
+    {% else %}
+    <div class="p-3 text-sm text-gray-700 max-h-48 overflow-y-auto whitespace-pre-wrap">{{ content_raw }}</div>
+    {% endif %}
+</div>
+{% endmacro %}

--- a/src/supervaizer/admin/templates/components/field_renderer.html
+++ b/src/supervaizer/admin/templates/components/field_renderer.html
@@ -14,14 +14,15 @@
 #}
 
 {% macro render_field(field, prefix="field_") %}
-<div class="mb-4">
-    <label for="{{ prefix }}{{ field.name }}" class="block text-sm font-medium text-gray-700 mb-1">
+<div class="flex flex-col h-full">
+    <label for="{{ prefix }}{{ field.name }}" class="block text-sm font-medium text-gray-700">
         {{ field.name }}
         {% if field.required %}<span class="text-red-500">*</span>{% endif %}
     </label>
     {% if field.description %}
-    <p class="text-xs text-gray-500 mb-1">{{ field.description }}</p>
+    <p class="text-xs text-gray-500 mt-0.5">{{ field.description }}</p>
     {% endif %}
+    <div class="mt-auto pt-1.5">
 
     {% if field.field_type == "CharField" %}
         {% if field.widget == "Textarea" %}
@@ -122,6 +123,7 @@
             class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
             {% if field.required %}required{% endif %}>
     {% endif %}
+    </div>{# end mt-auto input wrapper #}
 </div>
 {% endmacro %}
 
@@ -195,7 +197,11 @@
             {% if field_def.get("required") %}required{% endif %}>
             <option value="">-- Select --</option>
             {% for opt in field_def.get("options", []) %}
+            {% if opt is iterable and opt is not string and opt | length >= 2 %}
+            <option value="{{ opt[0] }}">{{ opt[1] }}</option>
+            {% else %}
             <option value="{{ opt }}">{{ opt }}</option>
+            {% endif %}
             {% endfor %}
         </select>
     {% elif ftype == "textarea" %}

--- a/src/supervaizer/admin/templates/workbench.html
+++ b/src/supervaizer/admin/templates/workbench.html
@@ -389,7 +389,7 @@
 </div>{# end workbenchPage #}
 
 {# ── Workbench JS ────────────────────────────────────────────────── #}
-<script src="/admin/static/js/workbench-form.js?v=12"></script>
+<script src="/admin/static/js/workbench-form.js?v=13"></script>
 <script>
     function applyConsoleFilter() {
         var container = document.getElementById('console-log-container');

--- a/src/supervaizer/admin/templates/workbench.html
+++ b/src/supervaizer/admin/templates/workbench.html
@@ -129,7 +129,7 @@
                 {% if job_fields %}
                 <div class="mb-5" id="fields-form">
                     <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-4">Job Parameters</h4>
-                    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    <div class="grid grid-cols-1 gap-x-4 gap-y-5 sm:grid-cols-2 lg:grid-cols-3 items-stretch">
                         {% for field in job_fields %}
                         {{ render_field(field, prefix="field_") }}
                         {% endfor %}
@@ -242,9 +242,7 @@
             <div
                 id="jobs-list-container"
                 class="max-h-[250px] overflow-y-auto"
-                hx-get="/admin/agents/{{ agent_slug }}/workbench/jobs"
-                hx-trigger="every 5s"
-                hx-swap="innerHTML"
+                data-url="/admin/agents/{{ agent_slug }}/workbench/jobs"
             >
                 <div class="px-4 py-6 text-center text-sm text-gray-400 italic">Loading...</div>
             </div>
@@ -377,9 +375,7 @@
             <div
                 id="console-log-container"
                 class="h-48 overflow-y-auto font-mono text-xs"
-                hx-get="/admin/agents/{{ agent_slug }}/workbench/console"
-                hx-trigger="every 2s"
-                hx-swap="innerHTML scroll:bottom"
+                data-url="/admin/agents/{{ agent_slug }}/workbench/console"
                 x-effect="$el.dataset.filter = filter; if (typeof applyConsoleFilter === 'function') applyConsoleFilter();"
             >
                 {# Placeholder — replaced by HTMX partial #}
@@ -393,7 +389,7 @@
 </div>{# end workbenchPage #}
 
 {# ── Workbench JS ────────────────────────────────────────────────── #}
-<script src="/admin/static/js/workbench-form.js"></script>
+<script src="/admin/static/js/workbench-form.js?v=11"></script>
 <script>
     function applyConsoleFilter() {
         var container = document.getElementById('console-log-container');
@@ -443,6 +439,9 @@
                         errorsContainerId: 'workbench-errors',
                         getApiKey: () => sessionStorage.getItem('admin_api_key') || document.body.dataset.adminKey || '{{ api_key }}',
                     });
+                    // Initial load of console and job history
+                    window.workbenchForm._refreshConsole();
+                    window.workbenchForm._refreshJobsList();
                     {% if active_job %}
                     // Resume tracking an active job from page load
                     window.workbenchForm.activeJobId = '{{ active_job.id }}';

--- a/src/supervaizer/admin/templates/workbench.html
+++ b/src/supervaizer/admin/templates/workbench.html
@@ -389,7 +389,7 @@
 </div>{# end workbenchPage #}
 
 {# ── Workbench JS ────────────────────────────────────────────────── #}
-<script src="/admin/static/js/workbench-form.js?v=11"></script>
+<script src="/admin/static/js/workbench-form.js?v=12"></script>
 <script>
     function applyConsoleFilter() {
         var container = document.getElementById('console-log-container');

--- a/src/supervaizer/admin/templates/workbench_monitor.html
+++ b/src/supervaizer/admin/templates/workbench_monitor.html
@@ -1,18 +1,14 @@
 {% from "components/field_renderer.html" import render_hitl_field, status_badge %}
+{% from "components/dialog_renderer.html" import render_hitl_dialog, render_dialog_confirmed %}
 
 {# Determine if the job has reached a terminal state (EntityStatus.value is lowercase) #}
 {% set job_status = job.status.value %}
 {% set is_terminal = job_status in ("completed", "failed", "stopped", "cancelled") %}
 
-{# Outer div — owns the polling loop via HTMX outerHTML swap #}
+{# Outer div — WebSocket pushes updates, no HTMX polling needed #}
 <div
     id="workbench-monitor-partial"
     data-job-terminal="{{ 'true' if is_terminal else 'false' }}"
-    hx-get="/admin/agents/{{ agent_slug }}/workbench/jobs/{{ job.id }}"
-    hx-swap="outerHTML"
-    {% if not is_terminal %}
-    hx-trigger="every 2s"
-    {% endif %}
 >
 
     {# ── Job status bar ──────────────────────────────────────────────── #}
@@ -40,6 +36,7 @@
         {% for case_info in cases_data %}
         {% set case = case_info.case %}
         {% set hitl_form = case_info.hitl_form %}
+        {% set hitl_dialog = case_info.hitl_dialog %}
         {% set case_status = case.status.value %}
         {% set auto_expand = case_status in ("awaiting", "in_progress") %}
 
@@ -66,7 +63,7 @@
                     </svg>
 
                     {# Case name #}
-                    <span class="text-sm font-medium text-gray-800 truncate">{{ case.name or case.id }}</span>
+                    <span class="text-sm font-medium text-gray-800 truncate"><span class="text-gray-400">Case:</span> {{ case.name or case.id }}</span>
 
                     {# Step count #}
                     {% if case.updates %}
@@ -132,7 +129,7 @@
                                     {% if step.index %}
                                     <span class="text-gray-400 mr-1">#{{ step.index }}</span>
                                     {% endif %}
-                                    {{ step.name or "Step" }}
+                                    {% if step.name == "HITL Answer" %}👤 {{ step_payload.get("_hitl_label", "User response") if step_payload is mapping else "User response" }}{% else %}{{ step.name or "Step" }}{% endif %}
                                 </span>
                                 <div class="flex items-center gap-2 flex-shrink-0">
                                     {% if step_duration is not none %}
@@ -148,7 +145,7 @@
                             {% endif %}
                             {% if step.name == "HITL Answer" and step_payload is mapping %}
                             <div class="mt-1 space-y-0.5">
-                                {% for key, val in step_payload.items() %}
+                                {% for key, val in step_payload.items() if key != "_hitl_label" %}
                                 <div class="text-xs">
                                     <span class="text-gray-400">{{ key }}:</span>
                                     {% if val is sameas true %}
@@ -169,6 +166,10 @@
                             {% endif %}
                         </div>
                     </div>
+                    {# Show approved content card below the step row #}
+                    {% if step_payload is mapping and step_payload.get("approved_content") %}
+                    {{ render_dialog_confirmed(step_payload.get("approved_content"), step_payload.get("approved_content_type", "text")) }}
+                    {% endif %}
                     {% endfor %}
                 </div>
                 {% else %}
@@ -208,6 +209,11 @@
                         </div>
                     </form>
                 </div>
+                {% endif %}
+
+                {# HITL dialog — chat-like interface for content review #}
+                {% if hitl_dialog and has_human_answer %}
+                {{ render_hitl_dialog(case.id, hitl_dialog) }}
                 {% endif %}
             </div>
         </div>

--- a/src/supervaizer/admin/templates/workbench_monitor.html
+++ b/src/supervaizer/admin/templates/workbench_monitor.html
@@ -132,8 +132,10 @@
                                     {% if step.name == "HITL Answer" %}👤 {{ step_payload.get("_hitl_label", "User response") if step_payload is mapping else "User response" }}{% else %}{{ step.name or "Step" }}{% endif %}
                                 </span>
                                 <div class="flex items-center gap-2 flex-shrink-0">
-                                    {% if step_duration is not none %}
+                                    {% if step_duration is not none and step_duration is number %}
                                     <span class="text-xs text-gray-400 font-mono">{{ "%.1f"|format(step_duration) }}s</span>
+                                    {% elif step_duration is not none and step_duration %}
+                                    <span class="text-xs text-gray-400 font-mono">{{ step_duration }}s</span>
                                     {% endif %}
                                     {% if step.cost %}
                                     <span class="text-xs text-gray-400 font-mono">${{ "%.4f"|format(step.cost) }}</span>

--- a/src/supervaizer/admin/templates/workbench_monitor.html
+++ b/src/supervaizer/admin/templates/workbench_monitor.html
@@ -166,6 +166,13 @@
                             {% endif %}
                         </div>
                     </div>
+                    {# Show reply content as a blockquote #}
+                    {% if step_payload is mapping and step_payload.get("reply") %}
+                    <div class="mx-4 mb-2 rounded border border-blue-200 bg-blue-50 p-3">
+                        <p class="text-xs font-medium text-blue-600 mb-1">Reply content:</p>
+                        <blockquote class="text-xs text-gray-700 whitespace-pre-wrap border-l-2 border-blue-300 pl-2">{{ step_payload.get("reply") }}</blockquote>
+                    </div>
+                    {% endif %}
                     {# Show approved content card below the step row #}
                     {% if step_payload is mapping and step_payload.get("approved_content") %}
                     {{ render_dialog_confirmed(step_payload.get("approved_content"), step_payload.get("approved_content_type", "text")) }}

--- a/src/supervaizer/admin/workbench_routes.py
+++ b/src/supervaizer/admin/workbench_routes.py
@@ -5,13 +5,15 @@
 # https://mozilla.org/MPL/2.0/.
 
 import asyncio
+import collections
+import hashlib
 import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
 import shortuuid
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from starlette.responses import Response
@@ -26,21 +28,27 @@ from supervaizer.lifecycle import EntityStatus
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 
 # Shared log buffer — populated via log listener registered in routes.py
-_workbench_log_buffer: list[dict[str, str]] = []
 _WORKBENCH_LOG_BUFFER_MAX = 500
+_workbench_log_buffer: collections.deque[dict[str, str]] = collections.deque(
+    maxlen=_WORKBENCH_LOG_BUFFER_MAX
+)
+
+
+# Counter incremented only for non-admin log entries (avoids WS feedback loop)
+_workbench_log_version = 0
 
 
 def workbench_log_listener(timestamp: str, level: str, message: str) -> None:
     """Log listener callback — appends to workbench buffer."""
+    global _workbench_log_version  # noqa: PLW0603
     _workbench_log_buffer.append({
         "timestamp": timestamp,
         "level": level,
         "message": message,
     })
-    if len(_workbench_log_buffer) > _WORKBENCH_LOG_BUFFER_MAX:
-        del _workbench_log_buffer[
-            : len(_workbench_log_buffer) - _WORKBENCH_LOG_BUFFER_MAX
-        ]
+    # Only bump version for meaningful logs (not HTTP access logs from admin endpoints)
+    if "/admin/" not in message and "HTTP/1.1" not in message:
+        _workbench_log_version += 1
 
 
 def _get_workbench_api_key(request: Request) -> str:
@@ -57,7 +65,7 @@ def _is_workbench_local_mode(request: Request) -> bool:
     return live is not None and getattr(live, "supervisor_account", None) is None
 
 
-def get_agent_by_slug(request: Request, slug: str) -> Agent:
+def get_agent_by_slug(request: Request | WebSocket, slug: str) -> Agent:
     """Look up a live Agent instance by its URL slug."""
     server = request.app.state.server
     for agent in server.agents:
@@ -121,6 +129,19 @@ def _normalize_hitl_form(form_data: dict) -> dict:
         if field_type == "ChoiceField" and "choices" in field:
             result[name]["options"] = field["choices"]
     return result
+
+
+def _compute_job_state_hash(job: "Job") -> str:
+    """Compute a hash of the job's observable state (status, cases, updates).
+
+    Used by the WebSocket endpoint to detect changes without sending full HTML.
+    """
+    parts: list[str] = [job.status.value]
+    cases = get_job_cases(job)
+    for case in cases:
+        parts.append(f"{case.id}:{case.status.value}:{len(case.updates)}")
+    raw = "|".join(parts)
+    return hashlib.md5(raw.encode()).hexdigest()
 
 
 def create_workbench_routes() -> APIRouter:
@@ -329,17 +350,24 @@ def create_workbench_routes() -> APIRouter:
             case_info = {
                 "case": case,
                 "hitl_form": None,
+                "hitl_dialog": None,
             }
             if case.status == EntityStatus.AWAITING:
                 # Find the HITL update in case.updates
                 for update in reversed(case.updates):
                     if hasattr(update, "payload") and update.payload:
                         payload = update.payload
-                        if isinstance(payload, dict) and "supervaizer_form" in payload:
-                            case_info["hitl_form"] = _normalize_hitl_form(
-                                payload["supervaizer_form"]
-                            )
-                            break
+                        if isinstance(payload, dict):
+                            if "supervaizer_dialog" in payload:
+                                case_info["hitl_dialog"] = payload[
+                                    "supervaizer_dialog"
+                                ]
+                                break
+                            elif "supervaizer_form" in payload:
+                                case_info["hitl_form"] = _normalize_hitl_form(
+                                    payload["supervaizer_form"]
+                                )
+                                break
             cases_data.append(case_info)
 
         return templates.TemplateResponse(
@@ -439,8 +467,20 @@ def create_workbench_routes() -> APIRouter:
                 detail=f"Case '{case_id}' is not awaiting input (current status: {case.status})",
             )
 
+        # Derive a human-readable label from the HITL step that prompted this answer
+        hitl_label = "User response"
+        for prev_update in reversed(case.updates):
+            if hasattr(prev_update, "payload") and prev_update.payload:
+                p = prev_update.payload
+                if isinstance(p, dict) and ("supervaizer_form" in p or "supervaizer_dialog" in p):
+                    hitl_label = prev_update.name or hitl_label
+                    break
+
         # Step 1: Transition case state AWAITING -> IN_PROGRESS
-        update = CaseNodeUpdate(name="HITL Answer", payload=answer_data)
+        answer_with_label = dict(answer_data) if isinstance(answer_data, dict) else answer_data
+        if isinstance(answer_with_label, dict):
+            answer_with_label["_hitl_label"] = hitl_label
+        update = CaseNodeUpdate(name="HITL Answer", payload=answer_with_label)
         case.receive_human_input(update)
 
         # Step 2: Invoke agent's human_answer method if defined
@@ -484,7 +524,8 @@ def create_workbench_routes() -> APIRouter:
         except (ValueError, TypeError):
             last_index = 0
 
-        entries_to_send = _workbench_log_buffer[last_index:]
+        buf = list(_workbench_log_buffer)
+        entries_to_send = buf[last_index:]
 
         return templates.TemplateResponse(
             request,
@@ -492,7 +533,7 @@ def create_workbench_routes() -> APIRouter:
             {
                 "request": request,
                 "entries": entries_to_send,
-                "next_index": len(_workbench_log_buffer),
+                "next_index": len(buf),
                 "agent_slug": slug,
             },
         )
@@ -521,3 +562,81 @@ def create_workbench_routes() -> APIRouter:
         )
 
     return router
+
+
+def create_workbench_ws_routes() -> APIRouter:
+    """Create WebSocket routes for workbench (no auth dependency — WS can't use APIKeyHeader)."""
+    ws_router = APIRouter(tags=["workbench-ws"])
+
+    @ws_router.websocket("/agents/{slug}/workbench/jobs/{job_id}/ws")
+    async def workbench_job_ws(websocket: WebSocket, slug: str, job_id: str) -> None:
+        """WebSocket that pushes typed refresh signals when state changes.
+
+        Sends: "monitor" (job/case state changed), "console" (new log entries),
+               "jobs" (job list changed). Client fetches the relevant partial.
+        """
+        await websocket.accept()
+        last_monitor_hash = ""
+        last_log_version = _workbench_log_version
+        last_jobs_count = -1
+        # Cache agent outside the loop — it doesn't change during a WS session
+        try:
+            agent = get_agent_by_slug(websocket, slug)
+        except Exception:
+            await websocket.close()
+            return
+        try:
+            while True:
+                try:
+                    job = Jobs().get_job(job_id, agent_name=agent.name)
+                except Exception:
+                    job = None
+
+                if not job:
+                    await websocket.send_text("monitor")
+                    break
+
+                # Monitor: job/case state changes
+                current_hash = _compute_job_state_hash(job)
+                if current_hash != last_monitor_hash:
+                    last_monitor_hash = current_hash
+                    await websocket.send_text("monitor")
+
+                # Console: only meaningful log entries (filtered, no admin HTTP noise)
+                if _workbench_log_version != last_log_version:
+                    last_log_version = _workbench_log_version
+                    await websocket.send_text("console")
+
+                # Jobs: job count changed
+                agent_jobs = Jobs().get_agent_jobs(agent.name)
+                if len(agent_jobs) != last_jobs_count:
+                    last_jobs_count = len(agent_jobs)
+                    await websocket.send_text("jobs")
+
+                is_terminal = job.status.value in (
+                    "completed", "failed", "stopped", "cancelled",
+                )
+                if is_terminal:
+                    await websocket.send_text("console")
+                    await websocket.send_text("jobs")
+                    await websocket.send_text("terminal")
+                    # Keep connection open but idle — prevents client reconnect loop
+                    try:
+                        while True:
+                            await asyncio.wait_for(websocket.receive_text(), timeout=60)
+                    except (asyncio.TimeoutError, WebSocketDisconnect):
+                        pass
+                    break
+
+                try:
+                    data = await asyncio.wait_for(
+                        websocket.receive_text(), timeout=2.0,
+                    )
+                    if data == "ping":
+                        await websocket.send_text("pong")
+                except asyncio.TimeoutError:
+                    pass
+        except WebSocketDisconnect:
+            pass
+
+    return ws_router

--- a/src/supervaizer/admin/workbench_routes.py
+++ b/src/supervaizer/admin/workbench_routes.py
@@ -79,12 +79,12 @@ def get_job_cases(job: Job) -> List[Any]:
     return list(Cases().get_job_cases(job.id).values())
 
 
-def get_agent_parameters_from_env(agent: Agent) -> Dict[str, Dict[str, str]]:
+def get_agent_parameters_from_env(agent: Agent) -> Dict[str, Dict[str, str | bool]]:
     """Pre-fill parameter values from environment variables.
 
     Returns dict of {name: {"value": str, "from_env": bool}}.
     """
-    values: Dict[str, Dict[str, str]] = {}
+    values: Dict[str, Dict[str, str | bool]] = {}
     if agent.parameters_setup:
         for name, param in agent.parameters_setup.definitions.items():
             env_val = os.environ.get(name, "")
@@ -210,6 +210,8 @@ def create_workbench_routes() -> APIRouter:
                 "local_mode": _is_workbench_local_mode(request),
                 "has_human_answer": agent.methods
                 and getattr(agent.methods, "human_answer", None) is not None,
+                "has_poll": agent.methods
+                and getattr(agent.methods, "job_poll", None) is not None,
                 "agents": [
                     {"slug": a.slug, "name": a.name}
                     for a in request.app.state.server.agents
@@ -359,9 +361,7 @@ def create_workbench_routes() -> APIRouter:
                         payload = update.payload
                         if isinstance(payload, dict):
                             if "supervaizer_dialog" in payload:
-                                case_info["hitl_dialog"] = payload[
-                                    "supervaizer_dialog"
-                                ]
+                                case_info["hitl_dialog"] = payload["supervaizer_dialog"]
                                 break
                             elif "supervaizer_form" in payload:
                                 case_info["hitl_form"] = _normalize_hitl_form(
@@ -413,6 +413,30 @@ def create_workbench_routes() -> APIRouter:
             return JSONResponse({"status": "stopped", "message": str(result.message)})
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to stop job: {e}")
+
+    @router.post("/agents/{slug}/workbench/jobs/{job_id}/poll")
+    async def workbench_poll_job(request: Request, slug: str, job_id: str) -> Response:
+        """Trigger manual poll for external updates on a job."""
+        agent = get_agent_by_slug(request, slug)
+
+        if not agent.methods or not agent.methods.job_poll:
+            raise HTTPException(status_code=404, detail="Agent has no poll method")
+
+        job_poll_method = agent.methods.job_poll.method
+
+        try:
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                None,
+                lambda: agent._execute(job_poll_method, {"job_id": job_id}),
+            )
+            return JSONResponse({
+                "status": result.status.value if result.status else "unknown",
+                "message": result.message or "Poll completed",
+                "payload": result.payload,
+            })
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to poll job: {e}")
 
     @router.get("/agents/{slug}/workbench/jobs/{job_id}/status")
     async def workbench_job_status(
@@ -472,12 +496,16 @@ def create_workbench_routes() -> APIRouter:
         for prev_update in reversed(case.updates):
             if hasattr(prev_update, "payload") and prev_update.payload:
                 p = prev_update.payload
-                if isinstance(p, dict) and ("supervaizer_form" in p or "supervaizer_dialog" in p):
+                if isinstance(p, dict) and (
+                    "supervaizer_form" in p or "supervaizer_dialog" in p
+                ):
                     hitl_label = prev_update.name or hitl_label
                     break
 
         # Step 1: Transition case state AWAITING -> IN_PROGRESS
-        answer_with_label = dict(answer_data) if isinstance(answer_data, dict) else answer_data
+        answer_with_label = (
+            dict(answer_data) if isinstance(answer_data, dict) else answer_data
+        )
         if isinstance(answer_with_label, dict):
             answer_with_label["_hitl_label"] = hitl_label
         update = CaseNodeUpdate(name="HITL Answer", payload=answer_with_label)
@@ -614,7 +642,10 @@ def create_workbench_ws_routes() -> APIRouter:
                     await websocket.send_text("jobs")
 
                 is_terminal = job.status.value in (
-                    "completed", "failed", "stopped", "cancelled",
+                    "completed",
+                    "failed",
+                    "stopped",
+                    "cancelled",
                 )
                 if is_terminal:
                     await websocket.send_text("console")
@@ -630,7 +661,8 @@ def create_workbench_ws_routes() -> APIRouter:
 
                 try:
                     data = await asyncio.wait_for(
-                        websocket.receive_text(), timeout=2.0,
+                        websocket.receive_text(),
+                        timeout=2.0,
                     )
                     if data == "ping":
                         await websocket.send_text("pong")

--- a/src/supervaizer/agent.py
+++ b/src/supervaizer/agent.py
@@ -457,6 +457,7 @@ class AgentMethodsAbstract(BaseModel):
     job_start: AgentMethod
     job_stop: AgentMethod | None = None
     job_status: AgentMethod | None = None
+    job_poll: AgentMethod | None = None
     human_answer: AgentMethod | None = None
     chat: AgentMethod | None = None
     custom: dict[str, AgentMethod] | None = None
@@ -496,6 +497,7 @@ class AgentMethods(AgentMethodsAbstract):
             "job_status": self.job_status.registration_info
             if self.job_status
             else None,
+            "job_poll": self.job_poll.registration_info if self.job_poll else None,
             "human_answer": self.human_answer.registration_info
             if self.human_answer
             else None,

--- a/src/supervaizer/cli.py
+++ b/src/supervaizer/cli.py
@@ -161,7 +161,8 @@ def start(
     os.environ["SUPERVAIZER_DEBUG"] = str(debug)
     os.environ["SUPERVAIZER_RELOAD"] = str(reload)
     if user_provided_public_url:
-        os.environ["SUPERVAIZER_PUBLIC_URL"] = public_url  # type: ignore[arg-type]
+        assert public_url is not None
+        os.environ["SUPERVAIZER_PUBLIC_URL"] = public_url
 
     # In local mode, load .env file so agent parameters are available.
     # CLI-provided values above won't be overridden (loader skips existing keys).
@@ -231,7 +232,7 @@ def start(
         )
         from supervaizer.server import Server as _Server
 
-        server_instance = _Server(
+        _local_server = _Server(
             agents=[],
             supervisor_account=None,
             a2a_endpoints=True,
@@ -244,7 +245,7 @@ def start(
             environment=environment,
             api_key=None,
         )
-        server_instance.launch(log_level=log_level)
+        _local_server.launch(log_level=log_level)
         return
 
     console.print(f"Loading configuration from [bold]{script_path}[/]")
@@ -274,7 +275,7 @@ def start(
     # find the Server and call launch().
     from supervaizer.server import Server as _Server
 
-    server_instance = None
+    server_instance: _Server | None = None
     for attr_name in dir(module):
         obj = getattr(module, attr_name, None)
         if isinstance(obj, _Server):

--- a/src/supervaizer/cli.py
+++ b/src/supervaizer/cli.py
@@ -105,8 +105,8 @@ app.add_typer(scaffold_app, name="scaffold", invoke_without_command=True)
 @app.command()
 def start(
     public_url: Optional[str] = typer.Option(
-        os.environ.get("SUPERVAIZER_PUBLIC_URL") or None,
-        help="Public URL to use for inbound connections",
+        None,
+        help="Public URL to use for inbound connections (reads SUPERVAIZER_PUBLIC_URL env var if not set)",
     ),
     host: str = typer.Option(
         os.environ.get("SUPERVAIZER_HOST", "0.0.0.0"), help="Host to bind the server to"
@@ -147,7 +147,24 @@ def start(
     ),
 ) -> None:
     """Start the Supervaizer Controller server."""
-    # In local mode, load .env file so agent parameters are available
+    # Track whether the user explicitly passed --public-url on the CLI.
+    # Since the default is None, a non-None value means it was explicit.
+    user_provided_public_url = public_url is not None
+
+    # Set CLI-provided env vars BEFORE .env loading so they take precedence.
+    # The .env loader skips keys already present in os.environ.
+    os.environ["SUPERVAIZER_HOST"] = host
+    os.environ["SUPERVAIZER_PORT"] = str(port)
+    os.environ["SUPERVAIZER_ENVIRONMENT"] = environment
+    os.environ["SUPERVAIZER_PERSISTENCE"] = str(persist).lower()
+    os.environ["SUPERVAIZER_LOG_LEVEL"] = log_level
+    os.environ["SUPERVAIZER_DEBUG"] = str(debug)
+    os.environ["SUPERVAIZER_RELOAD"] = str(reload)
+    if user_provided_public_url:
+        os.environ["SUPERVAIZER_PUBLIC_URL"] = public_url  # type: ignore[arg-type]
+
+    # In local mode, load .env file so agent parameters are available.
+    # CLI-provided values above won't be overridden (loader skips existing keys).
     if local:
         env_file = os.path.join(os.getcwd(), ".env")
         if os.path.isfile(env_file):
@@ -163,21 +180,11 @@ def start(
                     if key and key not in os.environ:
                         os.environ[key] = value
 
-    # Set environment variables for the server configuration
-    os.environ["SUPERVAIZER_HOST"] = host
-    os.environ["SUPERVAIZER_PORT"] = str(port)
-    os.environ["SUPERVAIZER_ENVIRONMENT"] = environment
-    os.environ["SUPERVAIZER_PERSISTENCE"] = str(persist).lower()
-    os.environ["SUPERVAIZER_LOG_LEVEL"] = log_level
-    os.environ["SUPERVAIZER_DEBUG"] = str(debug)
-    os.environ["SUPERVAIZER_RELOAD"] = str(reload)
-    if public_url is not None:
-        os.environ["SUPERVAIZER_PUBLIC_URL"] = public_url
-
     if local:
         os.environ["SUPERVAIZER_LOCAL_MODE"] = "true"
-        # In local mode, force public_url to localhost unless explicitly provided
-        if public_url is None:
+        # In local mode, force public_url to localhost unless the user
+        # explicitly passed --public-url on the CLI.
+        if not user_provided_public_url:
             public_url = f"http://{host}:{port}"
             os.environ["SUPERVAIZER_PUBLIC_URL"] = public_url
         console.print(
@@ -190,6 +197,12 @@ def start(
             f"[bold]API:[/] {base}/docs  [bold]Admin/Workbench:[/] {base}/admin/"
         )
         console.print(f"[dim]API key for /admin: {api_key_display}[/]")
+    else:
+        # Non-local mode: resolve public_url from env var if not explicitly provided
+        if not user_provided_public_url:
+            public_url = os.environ.get("SUPERVAIZER_PUBLIC_URL") or None
+            if public_url is not None:
+                os.environ["SUPERVAIZER_PUBLIC_URL"] = public_url
 
     if script_path is None:
         script_path = (

--- a/src/supervaizer/common.py
+++ b/src/supervaizer/common.py
@@ -23,6 +23,11 @@ log = logger.bind(module="supervaize")
 T = TypeVar("T")
 
 
+def is_local_mode() -> bool:
+    """Check if running in local test mode."""
+    return os.environ.get("SUPERVAIZER_LOCAL_MODE", "").lower() == "true"
+
+
 class SvBaseModel(BaseModel):
     """
     Base model for all Supervaize models.

--- a/src/supervaizer/server.py
+++ b/src/supervaizer/server.py
@@ -36,6 +36,7 @@ from supervaizer.common import (
     SvBaseModel,
     decrypt_value,
     encrypt_value,
+    is_local_mode,
     log,
 )
 from supervaizer.instructions import display_instructions
@@ -311,17 +312,15 @@ class Server(ServerAbstract):
         a2a_endpoints: bool = True,
         admin_interface: bool = True,
         scheme: str = "http",
-        environment: str = os.getenv("SUPERVAIZER_ENVIRONMENT", "dev"),
-        host: str = os.getenv("SUPERVAIZER_HOST", "0.0.0.0"),
-        port: int = int(os.getenv("SUPERVAIZER_PORT", 8000)),
+        environment: Optional[str] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
         debug: bool = False,
         reload: bool = False,
         mac_addr: str = "",
         private_key: Optional[RSAPrivateKey] = None,
-        public_url: Optional[str] = os.getenv("SUPERVAIZER_PUBLIC_URL", None),
-        api_key: Optional[str] = os.getenv(
-            "SUPERVAIZER_API_KEY", secrets.token_urlsafe(32)
-        ),
+        public_url: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the server with the given configuration.
@@ -343,8 +342,22 @@ class Server(ServerAbstract):
             api_key: API key for securing endpoints
 
         """
+        # Resolve defaults from env vars at call time (not class definition time).
+        # This ensures CLI-set env vars are picked up even when the module was
+        # imported before the CLI ran.
+        if environment is None:
+            environment = os.getenv("SUPERVAIZER_ENVIRONMENT", "dev")
+        if host is None:
+            host = os.getenv("SUPERVAIZER_HOST", "0.0.0.0")
+        if port is None:
+            port = int(os.getenv("SUPERVAIZER_PORT", "8000"))
+        if public_url is None:
+            public_url = os.getenv("SUPERVAIZER_PUBLIC_URL") or None
+        if api_key is None:
+            api_key = os.getenv("SUPERVAIZER_API_KEY") or secrets.token_urlsafe(32)
+
         # Local mode: skip Studio, inject Hello World, default api_key
-        local_mode = os.environ.get("SUPERVAIZER_LOCAL_MODE", "").lower() == "true"
+        local_mode = is_local_mode()
         if local_mode:
             if supervisor_account is not None:
                 log.warning(


### PR DESCRIPTION
Summary- Improve developer-facing and local workflow for agents, HITL, WebSocket monitoring, release automation.

- gh-release: simplify start justfile task to create/update GitHub releases based on latest tag reachable from origin/main; handle no-tag case and make deterministic and rer-safe.
- Dialog HIT: chat-like supervisor_dialog interface, async dialog fixes, double-click guard, buttons disabled during submission, and improved answer display (shows step label with 👤).
- WebSocket monitor: HTTP polling with push for monitor/console signals; keep terminal signal idle to avoid reconnect loops; visual improvements for reply/approved content.
- Local mode & env handling: force localhost URLs, skip SaaS events,-load .env, pre-fill agent from .env, resolve defaults at Server.__init__ call time, and load .env before CLI env setup.
- Tests: avoid subprocess in CLI start tests by using Server.launch; replace subprocess.Popen mocks; simplify assertions and improve test isolation.
- Workbench job polling: add job_poll AgentMethod and API POST agents/{slug}/workbench/jobs/{_id}/ to trigger polling; expose flag in template context and tighten type hints; bump workbench-form static to v13.
 Misc: ChoiceField unpacking for [value,label], aligned form layout, code cleanupis_local_mode helper, for buffer, JS extraction), cache bust bump v.