### PR TITLE
✨ chore: update changelog and remove redundant CI merge step- docs increment passed test in CHANGELOG to564 to the latest successful test run- ci: remove redundantMerge main back into develop" step from the publish-pi workflow. merge sequence caused unnecessary/

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -86,11 +86,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash tools/gh-release-latest-tag.sh supervaize/supervaizer
-
-      - name: Merge main back into develop
-        run: |
-          git fetch origin main develop
-          git checkout develop
-          git pull --ff-only origin develop
-          git merge --no-ff origin/main -m "chore: sync main back to develop"
-          git push origin develop

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 
 | Status     | Count |
 | ---------- | ----- |
-| ✅ Passed  | 563   |
+| ✅ Passed  | 564   |
 | 🤔 Skipped | 0     |
 | 🔴 Failed  | 0     |
 | ⏱️ in      | 69s   |


### PR DESCRIPTION
checkout/ operations during release runs removing it simplifies the workflow and accidental merges performed CI.