### PR TITLE
fix(ci): route Dependabot PRs to develop, not main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -21,6 +22,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -2,9 +2,9 @@ name: Security scan
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main]
+    branches: [main, develop]
   schedule:
     - cron: '23 6 * * *'
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,6 @@ This repository implements the following controls:
 - Trusted Publishing (OIDC) for PyPI releases — no long-lived publish tokens
 - Required reviewer approval on the `pypi` environment before publish secrets are exposed
 - Third-party GitHub Actions pinned to commit SHAs
-- OSV-Scanner in CI (daily + on every PR) against the OSV.dev malicious package index
+- OSV-Scanner in CI (daily + on every PR targeting `main` or `develop`) against the OSV.dev malicious package index
 
 If you observe a deviation from this posture, please report it via the private channel above.


### PR DESCRIPTION
## Summary

- Add `target-branch: "develop"` to both `pip` and `github-actions` ecosystems in `.github/dependabot.yml`

Dependabot was defaulting to the repository's default branch (`main`) when creating update PRs. This routes all Dependabot update PRs to `develop` instead, consistent with the standard development flow for this repo.

## Test plan

- [ ] Verify the next Dependabot PRs are opened against `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)