### PR TITLE
docs(changelog): add unreleased dependency security refresh entry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- **`uv.lock`** — Refreshed transitive versions to address open Dependabot / GHSA advisories on the default branch graph: **urllib3** (redirect and decompression-chain issues), **requests** (`extract_zipped_paths` temp reuse), **protobuf** (JSON recursion depth), **pyasn1** (decoder / recursion DoS), **pygments** (ReDoS in GUID lexer), and **uv** (ZIP / tar / RECORD handling; dev dependency via hatch).
+
 ## [0.20.0] - 2026-05-13
 
 ### Security


### PR DESCRIPTION
## Summary

- Adds `[Unreleased]` CHANGELOG entry documenting the `uv.lock` refresh that addressed open Dependabot / GHSA advisories: urllib3, requests, protobuf, pyasn1, pygments, and uv.