### PR TITLE
🧪 test(supervaizer): cover workbench job startup

### DIFF
--- a/.claude/repo-routine-state.json
+++ b/.claude/repo-routine-state.json
@@ -1,0 +1,4 @@
+{
+  "rotation": {"dead-code": {"last_slice": null}, "missing-tests": {"last_slice": "src/supervaizer/admin/workbench_routes.py"}},
+  "dedup_backlog": []
+}

--- a/tests/test_workbench_routes.py
+++ b/tests/test_workbench_routes.py
@@ -30,6 +30,7 @@ from supervaizer import (
     EntityStatus,
     Job,
     JobContext,
+    JobResponse,
     Parameter,
     ParametersSetup,
 )
@@ -204,6 +205,46 @@ class TestWorkbenchHitlAnswer:
 
         assert response.status_code == 404
         assert "missing-case" in response.json()["detail"]
+
+
+class TestWorkbenchStartJob:
+    """Test workbench job startup and parameter merging."""
+
+    def setup_method(self) -> None:
+        Jobs().reset()
+
+    def teardown_method(self) -> None:
+        Jobs().reset()
+
+    def test_start_job_uses_environment_parameter_fallback(
+        self,
+        test_client_with_agent: tuple[TestClient, str],
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        client, agent_slug = test_client_with_agent
+        monkeypatch.setenv("API_KEY", "from-env")
+        execute = mocker.patch.object(
+            Agent,
+            "_execute",
+            return_value=JobResponse(
+                job_id="workbench-job",
+                status=EntityStatus.COMPLETED,
+                message="done",
+            ),
+        )
+
+        response = client.post(
+            f"/manage/agents/{agent_slug}/workbench/start",
+            json={"parameters": {}, "fields": {"how_many": 3}},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "STARTING"
+        execute.assert_called_once()
+        params = execute.call_args.args[1]
+        assert params["fields"] == {"how_many": 3}
+        assert params["agent_parameters"] == [{"name": "API_KEY", "value": "from-env"}]
 
 
 class TestWorkbenchExecuteStep:


### PR DESCRIPTION
## Changes
- Add coverage for `workbench_start_job` environment fallback, submitted fields, and background execution parameters.
- Advance repo-routine missing-tests rotation state.

## Regression gate
- `just test`: 686 passed
- `just mypy`: passed
- Ruff check/format: passed
- GitNexus detect_changes vs `origin/main`: 1 test file, LOW risk, 0 affected production processes

## Dropped
- dead-code: no Vulture∩GitNexus candidates; Vulture unavailable in declared environment.
- remove-tests: no coverage-preserving candidates.
- dedup: no genuine low-risk duplication; closest candidates were different contracts or already shared.
- Remaining missing-test candidates deferred to a later rotation.