### PR TITLE
fix: publish wheels with metadata 2.5 without double-bumping

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -56,16 +56,28 @@ jobs:
           if echo "$MSG" | grep -qi '\[MAJOR\]'; then PART="major"
           elif echo "$MSG" | grep -qi '\[MINOR\]'; then PART="minor"
           elif echo "$MSG" | grep -qi '\[PATCH\]'; then PART="patch"
-          else PART="minor"
+          else
+            echo "No [MAJOR]/[MINOR]/[PATCH] token — skip bump, publish current version"
+            echo "part=skip" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "Bump type: $PART"
           echo "part=$PART" >> "$GITHUB_OUTPUT"
 
-      - name: Bump version and rotate CHANGELOG
+      - name: Sync with origin/main
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git pull --rebase origin main
+
+      - name: Bump version and rotate CHANGELOG
+        if: steps.bump-type.outputs.part != 'skip'
+        run: |
+          HEAD_MSG="$(git log -1 --format=%s)"
+          if echo "$HEAD_MSG" | grep -q 'chore(release):'; then
+            echo "HEAD is already a release commit after pull — skip bump"
+            exit 0
+          fi
           bump-my-version bump ${{ steps.bump-type.outputs.part }} \
             --config-file pyproject.toml \
             --verbose
@@ -78,9 +90,10 @@ jobs:
         run: hatch build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
+          skip-existing: true
 
       - name: Create or update GitHub release
         env:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PyPI publish (Metadata 2.5)** — Pin `pypa/gh-action-pypi-publish` to v1.14.2 so hatchling ≥1.32 wheels upload. Skip version bump unless the triggering commit has `[MAJOR]`/`[MINOR]`/`[PATCH]`.
+
 ## [1.5.0] - 2026-08-28
 
 ### Added


### PR DESCRIPTION
## Summary
- Pin `pypa/gh-action-pypi-publish` to v1.14.2 (`dc37677`) so hatchling ≥1.32 wheels with Metadata-Version 2.5 upload to PyPI.
- Skip version bump unless the triggering commit contains `[MAJOR]` / `[MINOR]` / `[PATCH]`, and skip if HEAD after `git pull` is already `chore(release):`. Unblocks publishing existing **v1.5.0** without bumping to 1.6.0.
- `skip-existing: true` so a retry does not fail if the wheel is already on PyPI.

Fixes failed publish job: https://github.com/supervaize/supervaizer/actions/runs/33161482947/job/98817032234

**Do not re-run that failed workflow** — it still has v1.14.1 and would bump again. Merge this PR to `main` (no bump token in the title) so the new workflow publishes 1.5.0.

## Test plan
- [ ] Merge this PR to `main` (approve `pypi` environment when publish waits)
- [ ] Confirm version stays `1.5.0` (no `chore(release): v1.6.0`)
- [ ] Confirm `supervaizer==1.5.0` on PyPI
- [ ] Confirm GitHub Release `v1.5.0` exists
- [ ] `just ship-reconcile` after PyPI is live


Made with [Cursor](https://cursor.com)